### PR TITLE
Fix for complex anonymous function syntax

### DIFF
--- a/lib/parse-stack.js
+++ b/lib/parse-stack.js
@@ -18,7 +18,7 @@ not, see <http://www.gnu.org/licenses/>.
  */
 var ensureType, formats, newline, parseStack;
 
-formats = [/^\x20+at\x20(?:([^(]+)\x20\()?(.*?)(?::(\d+):(\d+))?\)?$/, /^([^@]*)@(\S*):(\d+)$/];
+formats = [/^\x20+at\x20(?:(?:(.+?)\x20\((.*?)(?::(\d+):(\d+))?\))|(?:()(.*?)(?::(\d+):(\d+))?))$/, /^([^@]*)@(\S*):(\d+)$/];
 
 newline = /\r\n|\r|\n/;
 

--- a/src/parse-stack.coffee
+++ b/src/parse-stack.coffee
@@ -22,17 +22,29 @@ formats = [
 	///
 		^\x20+at\x20
 		(?:
-			([^(]+) # name
-			\x20\(
-		)?
-		(.*?)       # filepath
-		(?:
-			:
-			(\d+)   # lineNumber
-			:
-			(\d+)   # columnNumber
-		)?
-		\)?$
+			(?:
+				(.+?) # name
+				\x20
+				\(
+					(.*?) # filepath
+					(?:
+						:
+						(\d+) # lineNumber
+						:
+						(\d+) # columnNumber
+					)?
+				\)
+			)|(?:
+				()
+				(.*?) # filepath
+				(?:
+					:
+					(\d+) # lineNumber
+					:
+					(\d+) # columnNumber
+				)
+			?)
+		)$
 		///
 
 	# The @ format.

--- a/test/parse-stack.coffee
+++ b/test/parse-stack.coffee
@@ -127,6 +127,16 @@ describe "the at format", ->
 		assert lineNumber is 3
 		assert columnNumber is 1
 
+	it "handles a complex anonymous function syntax", ->
+		stack = parseStack
+			stack: "    at Object.o.(anonymous function) [as throwsErr] (/home/vpupkin/src/demo/index.js:51:16)"
+		assert stack.length is 1
+		{name, filepath, lineNumber, columnNumber} = stack[0]
+		assert name is "Object.o.(anonymous function) [as throwsErr]"
+		assert filepath is "/home/vpupkin/src/demo/index.js"
+		assert lineNumber is 51
+		assert columnNumber is 16
+
 	it "parses a nice example", ->
 		stack = parseStack
 			stack: """


### PR DESCRIPTION
Correctly handles cases like
`"    at Object.o.(anonymous function) [as throwsErr] (/home/vpupkin/src/demo/index.js:51:16)"`