### PR TITLE
Fix for complex anonymous function syntax

### DIFF
--- a/lib/parse-stack.js
+++ b/lib/parse-stack.js
@@ -16,9 +16,9 @@ General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with parse-stack. If
 not, see <http://www.gnu.org/licenses/>.
  */
-var ensureType, formats, newline, parseStack;
+var ensureType, formats, matchStackLine, newline, parseStack;
 
-formats = [/^\x20+at\x20(?:([^(]+)\x20\()?(.*?)(?::(\d+):(\d+))?\)?$/, /^([^@]*)@(\S*):(\d+)$/];
+formats = [[/^\x20+at\x20(.+?)\x20\((.*?)(?::(\d+):(\d+))?\)$/, /^\x20+at\x20()(.*?)(?::(\d+):(\d+))?$/], /^([^@]*)@(\S*):(\d+)$/];
 
 newline = /\r\n|\r|\n/;
 
@@ -48,7 +48,7 @@ parseStack = function(error) {
   _results = [];
   for (index = _j = 0, _len1 = stackLines.length; _j < _len1; index = ++_j) {
     stackLine = stackLines[index];
-    _ref1 = (_ref = stackLine.match(format)) != null ? _ref : [], match = _ref1[0], name = _ref1[1], filepath = _ref1[2], lineNumber = _ref1[3], columnNumber = _ref1[4];
+    _ref1 = (_ref = matchStackLine(format, stackLine)) != null ? _ref : [], match = _ref1[0], name = _ref1[1], filepath = _ref1[2], lineNumber = _ref1[3], columnNumber = _ref1[4];
     if (!match) {
       throw new Error("Unknown stack trace formatting on stack line " + (index + 1) + ":\n" + stackLine);
     }
@@ -64,6 +64,21 @@ parseStack = function(error) {
     });
   }
   return _results;
+};
+
+matchStackLine = function(format, line) {
+  var match, re, _i, _len;
+  if (format instanceof RegExp) {
+    return line.match(format);
+  }
+  for (_i = 0, _len = format.length; _i < _len; _i++) {
+    re = format[_i];
+    match = line.match(re);
+    if (match) {
+      break;
+    }
+  }
+  return match;
 };
 
 ensureType = function(type, value) {

--- a/test/parse-stack.coffee
+++ b/test/parse-stack.coffee
@@ -127,6 +127,16 @@ describe "the at format", ->
 		assert lineNumber is 3
 		assert columnNumber is 1
 
+	it "handles a complex anonymous function syntax", ->
+		stack = parseStack
+			stack: "    at Object.o.(anonymous function) [as throwsErr] (/home/vpupkin/src/demo/index.js:51:16)"
+		assert stack.length is 1
+		{name, filepath, lineNumber, columnNumber} = stack[0]
+		assert name is "Object.o.(anonymous function) [as throwsErr]"
+		assert filepath is "/home/vpupkin/src/demo/index.js"
+		assert lineNumber is 51
+		assert columnNumber is 16
+
 	it "parses a nice example", ->
 		stack = parseStack
 			stack: """


### PR DESCRIPTION
Correctly handles cases like
`"    at Object.o.(anonymous function) [as throwsErr] (/home/vpupkin/src/demo/index.js:51:16)"`

The drawback of this solution is that now each item in the `formats` array can be either a single regexp or an array of regexps. On the other hand, the regexps became more strict and robust.