### PR TITLE
Fix for complex anonymous function syntax

### DIFF
--- a/lib/parse-stack.js
+++ b/lib/parse-stack.js
@@ -16,9 +16,9 @@ General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with parse-stack. If
 not, see <http://www.gnu.org/licenses/>.
  */
-var ensureType, formats, newline, parseStack;
+var ensureType, formats, matchStackLine, newline, parseStack;
 
-formats = [/^\x20+at\x20(?:([^(]+)\x20\()?(.*?)(?::(\d+):(\d+))?\)?$/, /^([^@]*)@(\S*):(\d+)$/];
+formats = [[/^\x20+at\x20(.+?)\x20\((.*?)(?::(\d+):(\d+))?\)$/, /^\x20+at\x20()(.*?)(?::(\d+):(\d+))?$/], /^([^@]*)@(\S*):(\d+)$/];
 
 newline = /\r\n|\r|\n/;
 
@@ -37,7 +37,7 @@ parseStack = function(error) {
   });
   for (_i = 0, _len = formats.length; _i < _len; _i++) {
     format = formats[_i];
-    match = stackLines[0].match(format);
+    match = matchStackLine(format, stackLines[0]);
     if (match) {
       break;
     }
@@ -48,7 +48,7 @@ parseStack = function(error) {
   _results = [];
   for (index = _j = 0, _len1 = stackLines.length; _j < _len1; index = ++_j) {
     stackLine = stackLines[index];
-    _ref1 = (_ref = stackLine.match(format)) != null ? _ref : [], match = _ref1[0], name = _ref1[1], filepath = _ref1[2], lineNumber = _ref1[3], columnNumber = _ref1[4];
+    _ref1 = (_ref = matchStackLine(format, stackLine)) != null ? _ref : [], match = _ref1[0], name = _ref1[1], filepath = _ref1[2], lineNumber = _ref1[3], columnNumber = _ref1[4];
     if (!match) {
       throw new Error("Unknown stack trace formatting on stack line " + (index + 1) + ":\n" + stackLine);
     }
@@ -64,6 +64,21 @@ parseStack = function(error) {
     });
   }
   return _results;
+};
+
+matchStackLine = function(format, line) {
+  var match, re, _i, _len;
+  if (format instanceof RegExp) {
+    return line.match(format);
+  }
+  for (_i = 0, _len = format.length; _i < _len; _i++) {
+    re = format[_i];
+    match = line.match(re);
+    if (match) {
+      break;
+    }
+  }
+  return match;
 };
 
 ensureType = function(type, value) {

--- a/src/parse-stack.coffee
+++ b/src/parse-stack.coffee
@@ -15,25 +15,40 @@ You should have received a copy of the GNU Lesser General Public License along w
 not, see <http://www.gnu.org/licenses/>.
 ###
 
+# - Each entry is either a single regexp or an array of regexps.
 # - `\x20` matches a space.
 # - See also support/support.md
 formats = [
-	# The at format.
-	///
-		^\x20+at\x20
-		(?:
-			([^(]+) # name
-			\x20\(
-		)?
-		(.*?)       # filepath
-		(?:
-			:
-			(\d+)   # lineNumber
-			:
-			(\d+)   # columnNumber
-		)?
-		\)?$
+	[
+		# The at format with function name.
 		///
+			^\x20+at\x20
+			(.+?) # name
+			\x20
+			\(
+				(.*?) # filepath
+				(?:
+					:
+					(\d+) # lineNumber
+					:
+					(\d+) # columnNumber
+				)?
+			\)$
+			///
+
+		# The at format without function name.
+		///
+			^\x20+at\x20
+			() # empty name, keeping the capture groups order
+			(.*?) # filepath
+			(?:
+				:
+				(\d+) # lineNumber
+				:
+				(\d+) # columnNumber
+			)?$
+			///
+	]
 
 	# The @ format.
 	///
@@ -60,13 +75,13 @@ parseStack = (error)->
 	stackLines = stack.split(newline).filter((stackLine)-> stackLine isnt "")
 
 	for format in formats
-		match = stackLines[0].match(format)
+		match = matchStackLine(format, stackLines[0])
 		break if match
 	unless match
 		throw new Error "Unkown stack trace format:\n#{stack}"
 
 	for stackLine, index in stackLines
-		[match, name, filepath, lineNumber, columnNumber] = stackLine.match(format) ? []
+		[match, name, filepath, lineNumber, columnNumber] = matchStackLine(format, stackLine) ? []
 		unless match
 			throw new Error "Unknown stack trace formatting on stack line #{index+1}:\n#{stackLine}"
 
@@ -76,6 +91,13 @@ parseStack = (error)->
 		lineNumber   = ensureType(Number, lineNumber)
 		columnNumber = ensureType(Number, columnNumber)
 		{name, filepath, lineNumber, columnNumber}
+
+matchStackLine = (format, line)->
+	return line.match(format) if format instanceof RegExp
+	for re in format
+		match = line.match(re)
+		break if match
+	return match
 
 ensureType = (type, value)-> if value then type(value) else undefined
 

--- a/test/parse-stack.coffee
+++ b/test/parse-stack.coffee
@@ -127,6 +127,16 @@ describe "the at format", ->
 		assert lineNumber is 3
 		assert columnNumber is 1
 
+	it "handles a complex anonymous function syntax", ->
+		stack = parseStack
+			stack: "    at Object.o.(anonymous function) [as throwsErr] (/home/vpupkin/src/demo/index.js:51:16)"
+		assert stack.length is 1
+		{name, filepath, lineNumber, columnNumber} = stack[0]
+		assert name is "Object.o.(anonymous function) [as throwsErr]"
+		assert filepath is "/home/vpupkin/src/demo/index.js"
+		assert lineNumber is 51
+		assert columnNumber is 16
+
 	it "parses a nice example", ->
 		stack = parseStack
 			stack: """


### PR DESCRIPTION
Correctly handles cases like
`"    at Object.o.(anonymous function) [as throwsErr] (/home/vpupkin/src/demo/index.js:51:16)"`

The drawback of this solution is that now each item in the `formats` array
can be either a single regexp or an array of regexps. On the other hand,
the regexps became more strict and robust.
